### PR TITLE
Fixed typo in filter examples

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -303,7 +303,7 @@ the following code:
         --filter 'TestNamespace\\TestCaseClass::testMethod'
         --filter 'TestNamespace\\TestCaseClass'
         --filter TestNamespace
-        --filter TestCaseClase
+        --filter TestCaseClass
         --filter testMethod
         --filter '/::testMethod .*"my named data"/'
         --filter '/::testMethod .*#5$/'


### PR DESCRIPTION
Fixed typo where "testCaseClass" was instead "testCaseClase"