### PR TITLE
Fixing testCaseClass typo

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -321,7 +321,7 @@ the following code:
         --filter 'TestNamespace\\TestCaseClass::testMethod'
         --filter 'TestNamespace\\TestCaseClass'
         --filter TestNamespace
-        --filter TestCaseClase
+        --filter TestCaseClass
         --filter testMethod
         --filter '/::testMethod .*"my named data"/'
         --filter '/::testMethod .*#5$/'


### PR DESCRIPTION
Fixed typo TestCaseClase -> TestCaseClass in command line filter arg documentation. Opened against 8.5 as requested.